### PR TITLE
Changes ';' behaviour. Add source string to error report.

### DIFF
--- a/src/lisp.js
+++ b/src/lisp.js
@@ -473,6 +473,27 @@ export const STDLIB = {
     return eval_lisp(["begin"].concat(ast.slice(1)), ctx, rs);
   }),
 
+  "define": makeSF((ast, ctx, rs) => {
+    let context = {};
+    let ind = 0;
+    while (ind < ast.length && ast[ind][0] == "[") {
+      let last = ast[ind];
+      let body = last[last.length - 1][1];
+      context[last[1]] = makeSF((ast, ctx, rs) => {
+        if (!body) {
+          return false;
+        }
+        return eval_lisp(
+          ["let", [...last.slice(2, last.length - 1).map((x, i) => [x, ast[i]])], parse(body)],
+          ctx,
+          rs
+        );
+      });
+      ind++;// makeLetBindings(ast[0], ctx, rs)
+    }
+    return eval_lisp(['begin', ...ast.slice(ind)], {...context, ...ctx}, rs)
+  }),
+
   // system functions & objects
   // 'js': eval,
 

--- a/src/lisp.js
+++ b/src/lisp.js
@@ -12,6 +12,7 @@
  */
 
 import {parse} from './lpep';
+import {deparse} from './lped';
 import {DATE_TIME} from './lib/datetime';
 
 /**
@@ -29,6 +30,28 @@ export const isNumber = (arg) => (typeof arg === 'number');
 export const isBoolean = (arg) => arg === true || arg === false;
 export const isHash = (arg) => (typeof arg === 'object') && (arg !== null) && !isArray(arg);
 export const isFunction = (arg) => (typeof arg === 'function');
+
+
+function LPEEvalError(message) {
+  this.constructor.prototype.__proto__ = Error.prototype;
+  Error.call(this);
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+  // this.stack = (new Error()).stack;
+}
+
+function makeError(name, ast, message) {
+  const errorDescription = JSON.stringify(
+      {name: name, message: message, args: deparse([name, ...ast])
+        //ast.map(
+        //x => x instanceof Array ? `['${x.map(y => y instanceof Array ? [y[0]] : y).join("','")}']` : x)
+        },
+      ['name', 'message', 'args'],
+      4);
+
+  throw new LPEEvalError(errorDescription);
+}
 
 
 /**
@@ -476,22 +499,50 @@ export const STDLIB = {
   "define": makeSF((ast, ctx, rs) => {
     let context = {};
     let ind = 0;
-    while (ind < ast.length && ast[ind][0] == "[") {
+    let statics = $var$(ctx, '##static') || {};
+    while (ind < ast.length && isArray(ast[ind]) && ast[ind][0] == "[") {
       let last = ast[ind];
-      let body = last[last.length - 1][1];
+      let body = last[last.length - 1];
+      if (!body instanceof Array || body[0] != '"') {
+        makeError(last[1], last.slice(2), 'Last argument of define must be <String> ("func body at quotes")');
+      }
+      body = body[1];
+      let fargs = [];
+      statics[last[1]] = {};
+      last.slice(2, last.length - 1).forEach((v) => {
+        let name = v;
+        let val = undefined;
+        if (v instanceof Array) {
+          if (v[0] != "[") {
+            makeError(last[1], last.slice(2), 'Argument of function must be <name> or <Array>');
+          }
+          name = v[1];
+          val = eval_lisp(v[2], ctx, rs);
+        }
+        if (name.startsWith("#")) {
+          statics[last[1]][name.slice(1)] = val;
+        } else {
+          fargs.push([ name, val ]);
+        }
+      });
+
       context[last[1]] = makeSF((ast, ctx, rs) => {
         if (!body) {
           return false;
         }
+        let ths = $var$(ctx, '##static');
+        if (ths) ths = ths[last[1]];
         return eval_lisp(
-          ["let", [...last.slice(2, last.length - 1).map((x, i) => [x, ast[i]])], parse(body)],
+          ["let", 
+            [["this", ths || {}], ...fargs.map((x, i) => [x[0], ast[i] || x[1]])], 
+            parse(body)],
           ctx,
           rs
         );
       });
       ind++;// makeLetBindings(ast[0], ctx, rs)
     }
-    return eval_lisp(['begin', ...ast.slice(ind)], {...context, ...ctx}, rs)
+    return eval_lisp(['let', [["##static", statics]], ...ast.slice(ind)], {...context, ...ctx}, rs)
   }),
 
   // system functions & objects

--- a/src/lisp.js
+++ b/src/lisp.js
@@ -469,6 +469,10 @@ export const STDLIB = {
   }),
 
 
+  ';': makeSF((ast, ctx, rs) => {
+    return eval_lisp(["begin"].concat(ast.slice(1)), ctx, rs);
+  }),
+
   // system functions & objects
   // 'js': eval,
 

--- a/src/lpel.js
+++ b/src/lpel.js
@@ -46,7 +46,7 @@ export function makeError(t, message) {
 
   const errorDescription = JSON.stringify(
       t,
-      ['name', 'message', 'from', 'to', 'key', 'value', 'arity', 'first', 'second', 'third', 'fourth'],
+      ['name', 'message', 'src', 'crs', 'from', 'to', 'key', 'value', 'arity', 'first', 'second', 'third', 'fourth'],
       4);
 
   throw new LPESyntaxError(errorDescription);

--- a/src/lpep.js
+++ b/src/lpep.js
@@ -45,6 +45,7 @@ const make_parse = function (options = {}) {
   var m_token;
   var m_tokens;
   var m_token_nr;
+  var m_source;
 
   // стэк для типов выражений
   var m_expr_scope = { pop: function () {}};  // для разбора логических выражений типа (A and B or C)
@@ -152,6 +153,8 @@ const make_parse = function (options = {}) {
     m_token.to = t.to;
     m_token.value = v;
     m_token.arity = a;
+    m_token.src = m_source;
+    m_token.crs = m_source.split('').map((c, i) => i >= t.from && i < t.to ? "^" : "-").join("");
     if (a === "operator") {
       m_token.sexpr = m_operator_aliases[v];
     } else {
@@ -725,6 +728,7 @@ const make_parse = function (options = {}) {
   });
 
   return function (source) {
+    m_source = source;
     m_tokens = tokenize(source, {squareBrackets});
     m_token_nr = 0;
     new_expression_scope("logical");

--- a/src/lpep.js
+++ b/src/lpep.js
@@ -187,10 +187,10 @@ const make_parse = function (options = {}) {
         //console.log(token);
         if ( m_token.id === "(end)") {
             break;
-        } else if(m_token.value === ';'){
+        } /*else if(m_token.value === ';'){
           // skip optional ;
            advance();
-        }
+        }*/
         s = statement();
         //console.log("STATEMENT ", s);
         if (s) {
@@ -480,6 +480,24 @@ const make_parse = function (options = {}) {
 
     this.sexpr = [this.first.value].concat(a.map(function(el){return el.sexpr}));
     advance(")");
+    return this;
+  });
+
+
+  infix(";", 79, function (left) {
+    while (m_token.id === ";") {
+      advance();
+    }
+    if (["(end)", ")", "]", "}", ","].includes(m_token.id)) {
+      this.sexpr = left.sexpr;
+      m_expr_scope.pop();
+      return this;
+    }
+    
+    this.operands = [...(left.value === ";" ? left.operands : [left]), expression(79)];
+    this.arity = "binary";
+    this.sexpr = [";"].concat(this.operands.map(el => el.sexpr));
+    
     return this;
   });
 


### PR DESCRIPTION
* The behavior of ';' has been changed: now the operator is not skipped, but 'begin' is executed. Example `foo(a;b;c;) equals foo(begin(a,b,c))`
* Additional fields appear when an error is received.
```
LPESyntaxError: {
    "message": "Got $$ but expected ')'.",
    "src": "$$(b $$ c)",
    "crs": "-----^^---",
    "from": 5,
    "to": 7,
    "value": "$$",
    "arity": "name"
}
```