### PR TITLE
changes: change comma logic; add ... operation as expand object

### DIFF
--- a/src/lisp.js
+++ b/src/lisp.js
@@ -480,6 +480,36 @@ for (const [key, val] of Object.entries(STDLIB)) {
   if (isFunction(val)) {val.lpeName = key}
 }
 
+function expandObject(obj) {
+  if (isArray(obj)) {
+    return obj;
+  }
+  if (isHash(obj)) {
+    return Object.entries(obj);
+  }
+  return [obj];
+}
+
+function expandComma(ast, ctx, rs) {
+  if (!isArray(ast)) return ast;
+  let res = [];
+
+  ast.forEach(a => {
+    if (isArray(a)) {
+      if (a[0] == ",") {
+        res = res.concat(expandComma(a.slice(1), ctx, rs));
+      } else if (a[0] == "...") {
+        res = res.concat(expandComma(expandObject(eval_lisp(a[1], ctx, rs)), ctx, rs));
+      } else {
+        res.push(a);
+      }
+    } else {
+      res.push(a);
+    }
+  });
+  return res;
+}
+
 
 function macroexpand(ast, ctx, resolveString = true) {
   //console.log("MACROEXPAND: " + JSON.stringify(ast))
@@ -491,8 +521,7 @@ function macroexpand(ast, ctx, resolveString = true) {
     if (!isFunction(v)) break;
 
     if (!isMacro(v)) break;
-
-    ast = v.apply(v, ast.slice(1));                                             // Это макрос! 3-й элемент макроса установлен в 1 через push
+    ast = v.apply(v, expandComma(ast.slice(1), ctx, {"resolveString": resolveString}));
   }
   //console.log("MACROEXPAND RETURN: " + JSON.stringify(ast))
 
@@ -641,7 +670,7 @@ function EVAL(ast, ctx, options) {
     if (ast.length === 0) return null;                                                              // TODO: [] => empty list (or, maybe return vector [])
 
     //console.log("EVAL1: ", JSON.stringify(resolveOptions),  JSON.stringify(ast))
-    const [opAst, ...argsAst] = ast;
+    const [opAst, argsAst] = [ast[0], expandComma(ast.slice(1), ctx, options)];
 
     const op = EVAL(opAst, ctx, {... options, wantCallable: true});                                 // evaluate operator
 

--- a/src/lpep.js
+++ b/src/lpep.js
@@ -415,6 +415,20 @@ const make_parse = function (options = {}) {
 
   infix("*", 60);
   infix("/", 60);
+  infix(",", 1, function (left) {
+    while (m_token.id === ",") {
+      advance();
+    }
+    this.first = left;
+    if (m_token.id === "(end)") {
+      this.sexpr = left.sexpr;
+      return this;
+    }
+    this.second = expression(1);
+    this.arity = "binary";
+    this.sexpr = [","].concat(lift_funseq(this, ","));
+    return this;
+  });
 
   infix("(", 80, function (left) {
     let a = [];
@@ -430,49 +444,19 @@ const make_parse = function (options = {}) {
 
     // dima support for missed function arguments...
     if (m_token.id !== ")") {
-      if (false && (left.value == "where" || left.value == "filter" || left.value == "expr" || left.value == "logexpr")) {
-        // специальный парсер для where - logical expression.
-        // тут у нас выражение с использованием скобок, and, or, not и никаких запятых...
-        // DIMA 2021: logexpr function will be generic name for logical things
-        // where && filter is used for SQL generation and should not be changed....
-        // expr is deprecated name for logexpr
-        // FIXME: make transition to the logexpr!
-        new_expression_scope("logical");
-        var e = expression(0);
-        //console.log("LOGICAL" +  left.value + " " + JSON.stringify(e));
-        m_expr_scope.pop();
-        a.push(e);
-      } else {
-        new_expression_scope("lpe");
-        while (true) {
-          // console.log(">" + token.arity + " NAME:" + left.value);
-          if (m_token.id === ',') {
-            a.push({
-              value: null,
-              arity: "literal"
-            });
-            advance();
-          } else if (m_token.id === ')') {
-            a.push({
-              value: null,
-              arity: "literal"
-            });
-            break;
-          } else {
-            new_expression_scope("logical");
-            var e = expression(0);
-            //console.log("LOGICAL????? " + JSON.stringify(e));
-            m_expr_scope.pop();
-            // var e = statements();
-            a.push(e);
-            if (m_token.id !== ",") {
-              break;
-            }
-            advance(",");
-          }
+      new_expression_scope("lpe");
+      while (true) {
+        if (m_token.id === ')') {
+          break;
+        } else {
+          new_expression_scope("logical");
+          var e = expression(0);
+          m_expr_scope.pop();
+          a.push(e);
         }
-        m_expr_scope.pop();
       }
+      m_expr_scope.pop();
+      
     }
 
     this.sexpr = [this.first.value].concat(a.map(function(el){return el.sexpr}));
@@ -481,9 +465,9 @@ const make_parse = function (options = {}) {
   });
 
 
-  function lift_funseq(node) {
-    if (node.value === "->") {
-      return lift_funseq(node.first).concat(lift_funseq(node.second));
+  function lift_funseq(node, val = "->") {
+    if (node.value === val) {
+      return lift_funseq(node.first, val).concat(lift_funseq(node.second, val));
     } else /*if (node.value === "(") {
       console.log("() DETECTED" + JSON.stringify(node))
       //if (node.first.value === "->"){
@@ -542,6 +526,8 @@ const make_parse = function (options = {}) {
     return this;
   });
 
+
+  prefix("...");
 
   // WARNING HACK FIXME DIMA - добавил чтобы писать order_by(+a)
   // А также замена /table на +table в htSQL


### PR DESCRIPTION
## Изменена логика поведения запятой и скобок: 
`a + (b - 1, test(3,d), 4)` будет развернуто в
```json
[
  "+", 
  "a", 
  [
    "()",
    [
      ",",
      ["-", "b", 1],
      ["test", [",", 3, "d"]],
      4
    ]
  ]
]
```
При этом в `EVAL` добавлена обработка, что при нахождении запятой разворачивать ее и все вложенные запятые в массив аргументов.

## Добавлена операция разворачивания объекта `...`
`println(1, ...[2,3,4], 5, [6, 7, 8], ...{a: 9, b: 10})` развернется в 
`println(1, 2,3,4, 5, [6, 7, 8], ['a', 9], ['b', 10])`

При этом ... вычисляет значение операнда сразу же.