### PR TITLE
changes: set ';' as begin(...) operation

### DIFF
--- a/src/lisp.js
+++ b/src/lisp.js
@@ -469,6 +469,10 @@ export const STDLIB = {
   }),
 
 
+  ';': makeSF((ast, ctx, rs) => {
+    return eval_lisp(["begin"].concat(ast.slice(1)), ctx, rs);
+  }),
+
   // system functions & objects
   // 'js': eval,
 

--- a/src/lpep.js
+++ b/src/lpep.js
@@ -481,7 +481,7 @@ const make_parse = function (options = {}) {
   });
 
 
-  infix(";", 1, function (left) {
+  infix(";", 2, function (left) {
     while (m_token.id === ";") {
       advance();
     }


### PR DESCRIPTION
## Изменена работа операции `;`. Разворачивает операнды в Begin.
`print(a;b, c, d;e;);;; f ;;`
эквивалентно
`begin(print(begin(a,b), c, begin(d,e)), f)`