### PR TITLE
changes: add {a:12} declaration hashmap

### DIFF
--- a/src/lisp.js
+++ b/src/lisp.js
@@ -351,6 +351,7 @@ export const STDLIB = {
   'vector': makeSF((ast, ctx, rs) => {
     const evl = x => eval_lisp(x, ctx, rs);
     if (ast.length && isArray(ast[0]) && ast[0][0] == ":") {
+      let res = {};
       ast.forEach(x => { 
         let v = isArray(x) ? [evl(x[1]), evl(x[2])] : [x, evl(x)];
         res[v[0]] = v[1];

--- a/src/lisp.js
+++ b/src/lisp.js
@@ -347,7 +347,18 @@ export const STDLIB = {
   'new': (...args) => new (args[0].bind.apply(args[0], args)),
   'not': a => !a,
   'list': (...args) => args,
-  'vector': (...args) => args,
+  ':': (...args) => [args[0], args[1]],
+  'vector': makeSF((ast, ctx, rs) => {
+    const evl = x => eval_lisp(x, ctx, rs);
+    if (ast.length && isArray(ast[0]) && ast[0][0] == ":") {
+      ast.forEach(x => { 
+        let v = isArray(x) ? [evl(x[1]), evl(x[2])] : [x, evl(x)];
+        res[v[0]] = v[1];
+      });
+      return res;
+    }
+    return ast.map(x => evl(x));
+  }),
   'map': makeSF((ast, ctx, rs) => {
           let arr = eval_lisp(ast[0], ctx,  {...rs, wantCallable: false})
           rs.wantCallable = true

--- a/src/lpep.js
+++ b/src/lpep.js
@@ -385,7 +385,7 @@ const make_parse = function (options = {}) {
   infixr("::", 90);
 
   // for SQL as
-  infixr(":", 80);
+  infixr(":", 10);
 
   infix(":=", 30);
 


### PR DESCRIPTION
## Добавлена возможность создавать хэшмапы с помощью:
```js
let([[foo, 55], [bar, 'barv']],
    let([[a, {a: 5 +2, 10 + 3: min([1, 41]), oooo: bar, 'test'+3: 5, foo: -1, 'foo': -2, "foo": -3}]], 
    a))

{ a: 7, '13': 1, oooo: 'barv', test3: 5, '55': -1, foo: -3 }
```