### PR TITLE
changes: add eval_ast function

### DIFF
--- a/src/lisp.js
+++ b/src/lisp.js
@@ -240,6 +240,21 @@ const SPECIAL_FORMS = {                                                         
     const result = $var$(ctx, ast[0], undefined, rs);
     return result;
   }),
+  'set_options': makeSF((ast, ctx, rs) => {
+    const options = eval_lisp(ast[0], ctx, rs);
+    if (isArray(options)) {
+      // [["key1", "val1"], ["key2", "val2"]] => {key1: "val1", key2: "val2"}
+      options = Object.fromEntries(options);
+    }
+    const result = eval_lisp(ast[1], ctx, { ...rs, ...options });
+    return result;
+  }),
+  'eval_ast': makeSF((ast, ctx, options) => {
+    const astString = eval_lisp(ast[0], ctx, options);
+    const lisp = JSON.parse(astString);
+    const result = eval_lisp(lisp, ctx, options);
+    return result;
+  }),
   'eval_lpe': makeSF((ast, ctx, options) => {
     const lpeCode = eval_lisp(ast[0], ctx, options);
     const lisp = parse(lpeCode, options);

--- a/test/test-lisp.js
+++ b/test/test-lisp.js
@@ -77,6 +77,13 @@ describe('LISP tests', function () {
     assert.deepEqual(lpe.eval_lisp(["max", ["[", 3, 2, 1]]), 3);
   });
 
+  it('eval_ast', function () {
+    assert.deepEqual(lpe.eval_lisp(
+        lpe.parse(`eval_ast("[\\"+\\", 1, 2]")`)
+      ), 3
+    );
+  });
+
   it('and or not', function () {
     assert.deepEqual(lpe.eval_lpe('a or b', {"a":123}, {resolveString: true}), 123);
     assert.deepEqual(lpe.eval_lpe('a or b', {"a":123}, {resolveString: false}), 123);


### PR DESCRIPTION
Добавлены функции:
- `eval_ast`: принимает строкой JSON ast дерева и выполняет его:
```js
["eval_ast", "[\"+\", 1, 2]"]
```
- `set_options`: устанавливает `options` и выполняет 2-й аргумент с этими опциями:
```js
["set_options", { key1: "val1", key2: "val2" }, ["что-то для исполнения"]]
["set_options", [ ["key1", "val1"], ["key2", "val2"] ], ["что-то для исполнения"]]
```