### PR TITLE
Add skip form

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import {parse, LPESyntaxError} from './lpep';
 import {deparse} from './lped';
-import {eval_lisp, isString, isArray, isHash, isFunction, makeSF, isNumber, STDLIB, unbox} from './lisp';
+import {eval_lisp, isString, isArray, isHash, isFunction, makeSF, makeSkipForm, isNumber, STDLIB, unbox} from './lisp';
 
 function eval_lpe(lpe, ctx, options) {
   const ast = parse(lpe, options);
@@ -19,6 +19,7 @@ export {
   isFunction,
   isNumber,
   makeSF,
+  makeSkipForm,
   STDLIB,
   unbox
 };


### PR DESCRIPTION
Добавлена возможность в качестве результата контекстной функции вернуть функцию. При этом поиск по контексту продолжится дальше и вызовется нижележащая контекстная функция с тем же названием. Результат этой нижележащей функции будет передан в качестве аргумента первой функции.

```js
_context2["func"] = (args) => {
  // шаг 2 - вызов нижележащей функции
  return "some"
}

_context1["func"] = (args) => {
  // шаг 1 - вызов вышележащей функции
  return makeSkipForm((lowerFuncVal) => {
    // шаг 3 - вызов скип функции, где в качестве единственного агрумента - результат нижележащей функции
    return lowerFuncVal + "thing"
  })
}

eval_lisp(["func", args], [_context1, _context2])  // => Something


// Можно также использовать статик формы
_context1["func"] = makeSF((ast, ctx, rs) => {
  return makeSkipForm((lowerFuncVal)  => {
    return lowerFuncVal + "thing"
  })
})

// В качестве 2-го аргумента в makeSkipForm можно передать измененное ast дерево, 
// которое будет использоваться для всех нижележащих функций
// При этом не нужно в качестве 1-го элемента передавать имя функции (только аргументы)
_context1["func"] = makeSF((ast, ctx, rs) => {
  return makeSkipForm((lowerFuncVal)  => {
    return lowerFuncVal + "thing"
  },
  ["Новый элемент ast дерева", ...ast])
})
```
Если после  skip  функции ниже лежит другая skip функция, они будут вызываться по очереди, а результаты разворачиваться в обратном порядке.